### PR TITLE
Added  debertav2 to the possible model types in .check_model_type()

### DIFF
--- a/R/train.R
+++ b/R/train.R
@@ -34,7 +34,7 @@
     model_type <- gsub("-", "", tolower(model_type))
     if (!model_type %in% c("albert", "bert", "bertweet", "bigbird", "camembert", "deberta", "distilbert", "electra", "flaubert",
                            "herbert", "layoutlm", "layoutlmv2", "longformer", "mpnet", "mobilebert", "rembert", "roberta", "squeezebert",
-                           "squeezebert", "xlm", "xlmroberta", "xlnet")) {
+                           "squeezebert", "xlm", "xlmroberta", "xlnet", "debertav2")) {
         stop("Invalid `model_type`.", call. = FALSE)
     }
     return(model_type)    


### PR DESCRIPTION
Although not documented in https://simpletransformers.ai/docs/classification-specifics/#supported-model-types, it works nicely and allows for using models such as microsoft/deberta-v3-large.