### PR TITLE
Update methodshub.qmd

### DIFF
--- a/methodshub.qmd
+++ b/methodshub.qmd
@@ -89,10 +89,6 @@ With R installed:
 install.packages("grafzahl")
 ```
 
-## Repository structure
-
-This repository follows [the standard structure of an R package](https://cran.r-project.org/doc/FAQ/R-exts.html#Package-structure).
-
 ## How to Use
 <!--
 1. The how to use section should provide the list of steps that are necessary to produce the example output file (see section Output Data) after having set up the environment (see section Environment Setup).


### PR DESCRIPTION
Removing an outdated section, that does not need to be in the methodshub.qmd-file anymore to prepare for the methods hub launch.